### PR TITLE
this fixes strings like ~/.netrc which doesn’t get properly expanded and would result in nil results.

### DIFF
--- a/lib/looker-sdk/authentication.rb
+++ b/lib/looker-sdk/authentication.rb
@@ -86,7 +86,7 @@ module LookerSDK
       return unless netrc?
 
       require 'netrc'
-      info = Netrc.read netrc_file
+      info = Netrc.read File.expand_path(netrc_file)
       netrc_host = URI.parse(api_endpoint).host
       creds = info[netrc_host]
       if creds.nil?


### PR DESCRIPTION
Without this fix following the documentations suggested netrc config would result in a nil configuration

```
sdk = LookerSDK::Client.new(
  :netrc      => true,
  :netrc_file => "~/.net_rc",
  :api_endpoint => "https://mygreatcompany.looker.com:19999/api/3.0",

  # Disable cert verification if the looker has a self-signed cert.
  # Avoid this if using real certificates; verification of the server cert is a very good thing for production.
  # :connection_options => {:ssl => {:verify => false}},

  # Set longer timeout to allow for long running queries.
  # :connection_options => {:request => {:timeout => 60 * 60, :open_timeout => 30}},

  # Support self-signed cert *and* set longer timeout to allow for long running queries.
  # :connection_options => {:ssl => {:verify => false}, :request => {:timeout => 60 * 60, :open_timeout => 30}},
)
```
